### PR TITLE
Fix linking issue 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
 	"ohnosequences"         %% "statika"         % "2.0.0-M4",
-  "ohnosequences-bundles" %% "cdevel"          % "0.4.0-SNAPSHOT",
+  "ohnosequences-bundles" %% "cdevel"          % "0.3.0",
   "ohnosequences-bundles" %% "compressinglibs" % "0.3.0",
 	"ohnosequences-bundles" %% "ncurses"         % "0.3.0"
 )

--- a/src/main/scala/samtools.scala
+++ b/src/main/scala/samtools.scala
@@ -19,7 +19,7 @@ abstract class Samtools(val version: String)
   lazy val make: CmdInstructions = cmd("make")("-C", samtools.name)
 
   lazy val link: CmdInstructions = cmd("ln")("-s",
-    new File(s"${samtools.name}/samtoolsBinary").getCanonicalPath,
+    new File(s"${samtools.name}/samtools").getCanonicalPath,
     "/usr/bin/samtools"
   )
 


### PR DESCRIPTION
@eparejatobes @laughedelic this line does not link what we want to link and so samtools is not in the path 

https://github.com/ohnosequences-bundles/samtools/blob/master/src/main/scala/samtools.scala#L22

I'm fixing this, once fixed should I release 0.1.1 or 0.2.0?
